### PR TITLE
Add Modern Starter static site

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,34 @@
+name: Deploy site to Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Setup Pages
+        uses: actions/configure-pages@v4
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: "./site"
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/README.md
+++ b/README.md
@@ -1,1 +1,9 @@
-# MD
+# Modern Starter
+
+Static site located in the `site` directory.
+
+## Publishing with GitHub Pages
+1. Push changes to the `main` branch.
+2. In the repository settings under **Pages**, choose **GitHub Actions** as the source.
+3. The included workflow `.github/workflows/pages.yml` builds and deploys the `site` directory.
+4. After the workflow succeeds, visit the deployment URL shown in the Actions log to view the site.

--- a/site/index.html
+++ b/site/index.html
@@ -1,0 +1,70 @@
+<!DOCTYPE html>
+<html lang="en" class="dark">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>Modern Starter</title>
+  <script src="https://cdn.tailwindcss.com"></script>
+  <link rel="stylesheet" href="https://unpkg.com/swiper/swiper-bundle.min.css"/>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/glightbox/dist/css/glightbox.min.css"/>
+  <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.css"/>
+  <link rel="stylesheet" href="https://unpkg.com/leaflet/dist/leaflet.css"/>
+</head>
+<body class="bg-gray-900 text-white">
+  <header class="p-4 text-center text-2xl font-bold">Modern Starter</header>
+  <main class="p-4 space-y-8">
+    <section>
+      <div class="swiper mySwiper">
+        <div class="swiper-wrapper">
+          <div class="swiper-slide bg-gray-700 p-8 text-center">Slide 1</div>
+          <div class="swiper-slide bg-gray-700 p-8 text-center">Slide 2</div>
+          <div class="swiper-slide bg-gray-700 p-8 text-center">Slide 3</div>
+        </div>
+        <div class="swiper-pagination"></div>
+      </div>
+    </section>
+    <section>
+      <a href="https://via.placeholder.com/800x600" class="glightbox" data-gallery="g1">
+        <img src="https://via.placeholder.com/200" alt="sample" class="rounded"/>
+      </a>
+    </section>
+    <section id="templates" data-aos="fade-up">
+      <h2 class="text-xl font-semibold mb-2">Templates & Tools</h2>
+      <div class="space-y-2">
+        <div class="flex items-center gap-2">
+          <input id="tpl1" type="text" value="npm init -y" class="w-full p-2 text-gray-900">
+          <button class="copy-btn bg-blue-600 px-4 py-2 rounded" data-target="tpl1">Copy</button>
+        </div>
+      </div>
+    </section>
+    <section data-aos="fade-up">
+      <h2 class="text-xl font-semibold mb-2">Calculator</h2>
+      <div class="flex flex-col gap-2 w-full max-w-md">
+        <input id="revenue" type="number" placeholder="Revenue" class="p-2 text-gray-900">
+        <input id="expense" type="number" placeholder="Expense" class="p-2 text-gray-900">
+        <div>Profit: <span id="profit">0</span></div>
+        <canvas id="chart" height="100"></canvas>
+      </div>
+    </section>
+    <section data-aos="fade-up">
+      <h2 class="text-xl font-semibold mb-2">Map</h2>
+      <div id="map" class="w-full h-64"></div>
+    </section>
+    <section data-aos="fade-up">
+      <button id="openModal" class="bg-green-600 px-4 py-2 rounded">Open Modal</button>
+    </section>
+  </main>
+  <div id="modal" class="fixed inset-0 bg-black bg-opacity-75 flex items-center justify-center hidden">
+    <div class="bg-gray-800 p-4 rounded">
+      <p class="mb-4">This is a modal</p>
+      <button id="closeModal" class="bg-red-600 px-4 py-2 rounded">Close</button>
+    </div>
+  </div>
+  <script src="https://unpkg.com/swiper/swiper-bundle.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/glightbox/dist/js/glightbox.min.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/aos@2.3.4/dist/aos.js"></script>
+  <script src="https://cdn.jsdelivr.net/npm/chart.js"></script>
+  <script src="https://unpkg.com/leaflet/dist/leaflet.js"></script>
+  <script src="scripts.js"></script>
+</body>
+</html>

--- a/site/scripts.js
+++ b/site/scripts.js
@@ -1,0 +1,54 @@
+document.addEventListener('DOMContentLoaded', () => {
+  AOS.init();
+  const swiper = new Swiper('.mySwiper', { pagination: { el: '.swiper-pagination' } });
+  const lightbox = GLightbox();
+
+  document.querySelectorAll('.copy-btn').forEach(btn => {
+    btn.addEventListener('click', () => {
+      const target = document.getElementById(btn.dataset.target);
+      navigator.clipboard.writeText(target.value);
+    });
+  });
+
+  const revenueInput = document.getElementById('revenue');
+  const expenseInput = document.getElementById('expense');
+  const profitSpan = document.getElementById('profit');
+  const ctx = document.getElementById('chart').getContext('2d');
+  const chart = new Chart(ctx, {
+    type: 'bar',
+    data: {
+      labels: ['Revenue', 'Expense', 'Profit'],
+      datasets: [{
+        label: 'Amount',
+        data: [0, 0, 0],
+        backgroundColor: ['#16a34a', '#dc2626', '#2563eb']
+      }]
+    },
+    options: { responsive: true, scales: { y: { beginAtZero: true } } }
+  });
+
+  function update() {
+    const revenue = parseFloat(revenueInput.value) || 0;
+    const expense = parseFloat(expenseInput.value) || 0;
+    const profit = revenue - expense;
+    profitSpan.textContent = profit;
+    chart.data.datasets[0].data = [revenue, expense, profit];
+    chart.update();
+  }
+
+  revenueInput.addEventListener('input', update);
+  expenseInput.addEventListener('input', update);
+
+  const map = L.map('map').setView([39.1031, -84.5120], 13);
+  L.tileLayer('https://{s}.tile.openstreetmap.org/{z}/{x}/{y}.png', {
+    attribution: '&copy; OpenStreetMap contributors'
+  }).addTo(map);
+
+  const modal = document.getElementById('modal');
+  document.getElementById('openModal').addEventListener('click', () => {
+    modal.classList.remove('hidden');
+  });
+  document.getElementById('closeModal').addEventListener('click', () => {
+    modal.classList.add('hidden');
+  });
+});


### PR DESCRIPTION
## Summary
- add Modern Starter static site using Tailwind, Swiper, GLightbox, AOS, Chart.js, and Leaflet
- include dark theme, modal, templates/tools copy buttons, live revenue calculator with bar chart, and Cincinnati map
- configure GitHub Pages workflow for deploying `site` via Actions

## Testing
- `curl -I -s https://cdn.tailwindcss.com | head -n 1`
- `curl -I -s https://unpkg.com/swiper/swiper-bundle.min.js | head -n 1`
- `curl -I http://localhost:8000/site/index.html | head -n 1`

------
https://chatgpt.com/codex/tasks/task_e_689ce85ed860832399c2e8abf385af28